### PR TITLE
Updated date_parser function

### DIFF
--- a/maad/util/parser.py
+++ b/maad/util/parser.py
@@ -395,9 +395,9 @@ def date_parser (datadir, dateformat ="SM4", extension ='.wav', verbose=False):
                 if dateformat == "SM4":
                     c_date.append(_date_from_filename(file_stem))      
                 elif dateformat == "POSIX" :
-                    posix_time = int(file_stem, 16)
-                    dd = datetime.utcfromtimestamp(posix_time).strftime('%Y-%m-%d %H:%M:%S')
-                    c_date.append(dd)                          
+                    date_format = '%Y%m%d_%H%M%S'
+                    dd = datetime.strptime(file_stem, date_format).strftime('%Y-%m-%d %H:%M:%S')
+                    c_date.append(dd)                         
                 
     ####### SORTED BY DATE
     # create a Pandas dataframe with date as index


### PR DESCRIPTION
Hello!
This Pull Request fixes date parser for AudioMoth file processing.
In the Windows system, the date_parser util fails to work for files generated by AudioMoth. 
I have created a workaround by using the `strptime` function to directly read the date and time from the file name, without the need for any POSIX conversions. 
Hope this helps!

refer bug: #83 