### PR TITLE
Fix the audio file format from xeno-canto

### DIFF
--- a/maad/util/xeno_canto.py
+++ b/maad/util/xeno_canto.py
@@ -412,8 +412,9 @@ def xc_download(df,
                 os.makedirs(path)
             #------------------------------------------------------------------
             # get filenames
-            filename = 'XC' + str(index) + '.mp3'
-            # test if the mp3 file already exists
+            audio_format = '.' + row['file-name'].split('.')[-1]
+            filename = 'XC' + str(index) + audio_format
+            # test if the file already exists
             if os.path.exists(rootdir / dataset_name / name_dir / filename) == True:
                 fullpath_list += [path / filename]
                 if verbose :


### PR DESCRIPTION
The previous version of the function xc_download saved the files using .mp3 format by default. This pull request changes the default .mp3 format for the original audio format. 