### PR TITLE
Fixed edge with returning index when index is not defined

### DIFF
--- a/maad/util/miscellaneous.py
+++ b/maad/util/miscellaneous.py
@@ -82,6 +82,9 @@ def index_bw(fn, bw):
         index = np.zeros(len(fn))
         index[(abs(fn-bw)).argmin()] = 1
         index = [bool(x) for x in index]
+    else:
+        index = (np.ones(len(fn)))
+        index = [bool(x) for x in index]
     return index
 
 # %%


### PR DESCRIPTION
Index may not be defined here. This ensures that an error will not be thrown if there is an edge case, as there was in my project.